### PR TITLE
feat: Add GitHub Actions workflow for PR/Issue comment monitoring

### DIFF
--- a/.github/workflows/comment-monitor.yml
+++ b/.github/workflows/comment-monitor.yml
@@ -1,0 +1,31 @@
+name: PR/Issue Comment Monitor
+
+on:
+  issue_comment:
+    types: [created]
+
+# Set minimum permissions by default
+permissions:
+  contents: read
+
+jobs:
+  comment-monitor:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor != 'dependabot[bot]' }}
+    timeout-minutes: 5
+    steps:
+      - name: Print comment information
+        run: |
+          echo "New comment detected:"
+          echo "Author: @${{ github.event.comment.user.login }}"
+          echo "PR/Issue: #${{ github.event.issue.number }}"
+          echo "Content: ${{ github.event.comment.body }}"
+          echo "Timestamp: ${{ github.event.comment.created_at }}"
+          echo "Repository: ${{ github.repository }}"
+          echo ""
+          echo "Additional Details:"
+          echo "Comment ID: ${{ github.event.comment.id }}"
+          echo "Comment URL: ${{ github.event.comment.html_url }}"
+          echo "Issue/PR Title: ${{ github.event.issue.title }}"
+          echo "Issue/PR State: ${{ github.event.issue.state }}"
+          echo "Action: ${{ github.event.action }}"

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -34,3 +34,10 @@ The system is ready to accept a new task assignment. The previous task has been:
 
 ---
 **Context Reset**: Ready for new task assignment
+
+## Current Task: GitHub Actions Comment Monitoring Workflow
+- Issue: #8
+- Complexity: Level 1 (Quick Feature Addition)
+- Branch: task-20250111-pr-issue-comment-monitoring
+- Status: VAN mode initialization complete
+- Next Step: Implement workflow file

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -73,3 +73,17 @@
 - File not found scenarios
 
 **STATUS: Ready for testing and integration** ✅
+
+## 2025-01-11: GitHub Actions Comment Monitoring Workflow Added
+- **Issue**: #8 - Add GitHub Actions workflow for PR/Issue comment monitoring
+- **Complexity**: Level 1 (Quick Feature Addition)
+- **Files Created**:
+  - /.github/workflows/comment-monitor.yml: Verified and committed
+- **Key Implementation**:
+  - Event trigger: issue_comment with types [created]
+  - Single job with minimal ubuntu-latest setup
+  - Outputs: comment author, body, PR/Issue number, repository, timestamp
+  - Follows existing CI patterns with minimal permissions
+- **Validation**: Pre-commit hooks passed including workflow validation
+- **Status**: Complete and ready for testing with real comments
+- **Next Steps**: Create PR for review and testing

--- a/memory-bank/tasks.md
+++ b/memory-bank/tasks.md
@@ -1,284 +1,76 @@
-# Task: Implement End-to-End Tests with Subprocess Execution and Coverage Collection
+# GitHub Actions Workflow for PR/Issue Comment Monitoring
 
 ## Description
-Need to implement comprehensive end-to-end (e2e) tests that run the built flow-test-go application as a subprocess with proper test isolation and coverage collection.
+Add a GitHub Actions workflow that automatically runs when new comments are added to Pull Requests or Issues. The workflow should have a single step that prints information about the comment to the console.
 
 ## GitHub Issue
-Issue #5: https://github.com/ondatra-ai/flow-test-go/issues/5
+Issue #8: https://github.com/ondatra-ai/flow-test-go/issues/8
 
 ## Complexity
-Level: 3
-Type: Intermediate Feature
-
-## Technology Stack
-- Language: Go 1.21+
-- Testing Framework: Go standard testing package + testify
-- Coverage Tool: Go 1.20+ coverage with GOCOVERDIR support
-- Build Tool: Make
-- CI/CD: GitHub Actions
-
-## Technology Validation Checkpoints
-
-### Technology Validation Results (POC Completed)
-- ✅ Go version 1.24.5 supports GOCOVERDIR
-- ✅ Built binary with -cover flag successfully
-- ✅ GOCOVERDIR collected coverage data (covcounters and covmeta files)
-- ✅ Converted coverage data to standard format with go tool covdata
-- ✅ Generated coverage report showing 50% coverage for POC
-- [x] Go 1.20+ available (required for GOCOVERDIR coverage mode)
-- [x] Build with -cover flag produces instrumented binary
-- [x] GOCOVERDIR environment variable collects coverage data
-- [x] go tool covdata can merge coverage files
-- [x] Subprocess execution with os/exec package works
+Level: 1
+Type: Quick Feature Addition
 
 ## Key Results
-1. **E2E Test Infrastructure**: Create robust subprocess testing framework that runs the built application binary
-2. **Test Isolation**: Each test runs in dedicated temporary directory with complete isolation between tests
-3. **Coverage Collection**: Successfully collect coverage data from subprocess execution using -cover build flags
-4. **Coverage Aggregation**: Combine coverage from all e2e tests into single comprehensive report
-5. **CI/CD Integration**: Seamlessly integrate with existing GitHub Actions workflow
-6. **Test Reliability**: All e2e tests pass consistently without flakiness
-7. **Documentation**: Clear documentation for writing and maintaining e2e tests
+1. ✅ **Workflow Creation**: Created comment-monitor.yml in .github/workflows/
+2. ✅ **Trigger Configuration**: Set up issue_comment event trigger for both PRs and Issues
+3. ✅ **Output Format**: Print comment author, body, PR/Issue number, repository, timestamp
+4. ✅ **CI Pattern Compliance**: Follow existing permissions and structure patterns from ci.yml
 
 ## Requirements Analysis
 - Core Requirements:
-  - [x] Build application with coverage instrumentation
-  - [x] Execute application as subprocess in tests
-  - [x] Collect coverage data from subprocess execution
-  - [x] Aggregate coverage from multiple test runs
-  - [x] Integrate with existing CI/CD pipeline
+  - [x] Trigger on issue_comment events (both PRs and Issues)
+  - [x] Single job with minimal setup
+  - [x] Output all required comment information
+  - [x] Follow existing CI patterns
 - Technical Constraints:
-  - [x] Go 1.20+ required for GOCOVERDIR support
-  - [x] Tests must be isolated (no shared state)
-  - [x] Coverage data must be preserved between runs
-
-## Component Analysis
-- Affected Components:
-  - **Makefile**
-    - Changes needed: Add build-e2e-coverage and test-e2e targets
-    - Dependencies: None
-  - **tests/e2e/**
-    - Changes needed: Complete rewrite with subprocess testing framework
-    - Dependencies: os/exec, testing, testify
-  - **.github/workflows/ci.yml**
-    - Changes needed: Update e2e-tests job to collect coverage
-    - Dependencies: Coverage artifacts upload
-  - **tests/e2e/README.md** (new)
-    - Changes needed: Create comprehensive documentation
-    - Dependencies: None
-
-## Functional Changes (E2E Test Cases)
-- **Test Case 1: Basic Flow Execution**
-  - Execute simple linear flow (hello-world.json)
-  - Verify flow completes successfully
-  - Check output matches expected results
-- **Test Case 2: Conditional Flow Testing**
-  - Test flows with conditional branching
-  - Verify correct path selection based on conditions
-  - Test nested conditions and complex logic
-- **Test Case 4: Error Scenarios**
-  - Test invalid flow files (malformed JSON, missing fields)
-  - Test flows with circular references
-  - Test timeout handling and interruption
-- **Test Case 5: Advanced Flow Features**
-  - Test flows with loops and complex navigation
-  - Test complex flow navigation patterns
-  - Test performance with large flows
-- Architecture:
-  - [x] Use subprocess testing pattern with os/exec
-  - [x] Create test helper package for common operations
-  - [x] Use t.TempDir() for automatic cleanup
-- Coverage Collection:
-  - [x] Use GOCOVERDIR for subprocess coverage
-  - [x] Aggregate with go tool covdata
-  - [x] Generate HTML reports for visualization
-- Test Organization:
-  - [x] One test file per feature area
-  - [x] Shared test utilities in helper package
-  - [x] Parallel test execution where possible
+  - [x] Use ubuntu-latest runner
+  - [x] Minimal permissions (read-only)
+  - [x] No external dependencies
 
 ## Implementation Strategy
+1. [x] Create .github/workflows/comment-monitor.yml
+2. [x] Configure issue_comment trigger
+3. [x] Set minimal permissions
+4. [x] Add single job with output step
+5. [x] Use GitHub context variables for comment data
+6. [x] Test with commit validation
 
-### Phase 0: Technology Validation
-1. [ ] Verify Go version supports GOCOVERDIR
-2. [ ] Create minimal POC with coverage collection
-3. [ ] Test coverage aggregation workflow
+## Implementation Details
 
-### Phase 1: Infrastructure Setup
-1. [ ] Update Makefile with new targets
-   - [ ] build-e2e-coverage target
-   - [ ] test-e2e target
-   - [ ] coverage-e2e-report target
-2. [ ] Create test helper package (tests/e2e/testutil/)
-   - [ ] Binary builder with coverage flags
-   - [ ] Subprocess executor with timeout
-   - [ ] Coverage collector utility
-   - [ ] Test environment setup helper
+### Workflow File: `.github/workflows/comment-monitor.yml`
+- **Event Trigger**: `issue_comment` with `types: [created]`
+- **Permissions**: `contents: read` (minimal)
+- **Runner**: `ubuntu-latest`
+- **Timeout**: 5 minutes
+- **Dependabot Exclusion**: `if: ${{ github.actor != 'dependabot[bot]' }}`
 
-### Phase 2: Core E2E Tests
-1. [x] Remove placeholder_test.go
-2. [x] Create test flow files in testdata/flows/
-   - [x] Basic single-step flow (single-step.json)
-   - [x] Multi-step flow with sequential execution (multi-step.json)
-   - [x] Conditional flow with branching (with-conditions.json)
-   - [x] Error case flows (invalid-json.json, missing-initial.json, invalid-step-ref.json, circular-ref.json)
-3. [x] Create flow_basic_test.go
-   - [x] Test single-step flow execution
-   - [x] Test multi-step flow execution
-   - [x] Test timeout handling
-   - [x] Test execution order
-4. [x] Create flow_conditional_test.go
-   - [x] Test conditional flow execution
-   - [x] Test branch selection
-   - [x] Test performance
-5. [x] Create flow_error_test.go
-   - [x] Test invalid JSON handling
-   - [x] Test missing initial step
-   - [x] Test invalid step references
-   - [x] Test circular references
-   - [x] Test non-existent files
-6. [x] Create testutil package
-   - [x] builder.go - Fluent test API
-   - [x] runner.go - Subprocess execution
-   - [x] coverage.go - Coverage collection
-7. [x] Update Makefile with e2e targets
-   - [x] build-e2e-coverage target
-   - [x] test-e2e target
-   - [x] coverage-e2e-report target
+### Output Information
+- Comment author: `@${{ github.event.comment.user.login }}`
+- Comment body: `${{ github.event.comment.body }}`
+- PR/Issue number: `#${{ github.event.issue.number }}`
+- Repository: `${{ github.repository }}`
+- Timestamp: `${{ github.event.comment.created_at }}`
+- Additional details: Comment ID, URL, issue title, state, action
 
-### Phase 3: Coverage Integration
-1. [ ] Implement coverage collection in each test
-2. [ ] Create coverage aggregation script
-3. [ ] Update CI workflow for coverage artifacts
-4. [ ] Add coverage reporting to PR comments
-
-### Phase 4: Documentation & Polish
-1. [x] Create comprehensive README.md
-   - [x] Complete test framework documentation
-   - [x] Usage examples and troubleshooting
-   - [x] Coverage collection guide
-2. [x] Add example test templates
-   - [x] FlowTestBuilder API examples
-   - [x] Test writing guidelines
-3. [x] Document debugging procedures
-   - [x] Common issues and solutions
-   - [x] Debugging commands and tips
-4. [ ] Performance optimization (future enhancement)
-
-## Testing Strategy
-- Unit Tests:
-  - [ ] Test helper utilities
-  - [ ] Test coverage collection logic
-- Integration Tests:
-  - [ ] All e2e tests ARE integration tests
-  - [ ] Test parallel execution
-  - [ ] Test coverage aggregation
-- Reliability Tests:
-  - [ ] Run tests 10x to verify no flakiness
-  - [ ] Test with different OS environments
-
-## Documentation Plan
-- [ ] E2E Test Developer Guide (tests/e2e/README.md)
-- [ ] Coverage Collection Guide
-- [ ] Troubleshooting Guide
-- [ ] CI/CD Integration Notes
-
-## Dependencies
-- os/exec (standard library)
-- testing (standard library)
-- github.com/stretchr/testify
-- Go 1.20+ toolchain
-
-## Challenges & Mitigations
-- **Challenge**: Coverage collection from subprocess
-  - **Mitigation**: Use GOCOVERDIR environment variable (Go 1.20+)
-- **Challenge**: Test isolation and cleanup
-  - **Mitigation**: Use t.TempDir() for automatic cleanup
-- **Challenge**: Flaky tests due to timing
-  - **Mitigation**: Implement proper timeouts and retry logic
-- **Challenge**: CI/CD coverage aggregation
-  - **Mitigation**: Use go tool covdata for merging
-
-## Creative Phases Required
-- [x] Test Framework Architecture Design
-- [x] Coverage Collection Strategy Design
-- [x] CI/CD Integration Architecture
+### Validation
+- [x] Workflow file created successfully
+- [x] Pre-commit hooks passed (including workflow validation)
+- [x] Git commit completed successfully
+- [x] Follows existing CI patterns from ci.yml
 
 ## Branch
-- Name: task-20250109-e2e-subprocess-tests
+- Name: task-20250111-pr-issue-comment-monitoring
 - Created: ✅
+- Committed: ✅
 
 ## Status
 - [x] Initialization complete
-- [x] Planning complete
-- [x] Creative phase complete
-- [x] Technology validation complete
-- [x] Phase 1: Infrastructure Setup complete
-- [x] Phase 2: Core E2E Tests complete
-- [x] Phase 3: Coverage Integration complete
-- [x] Phase 4: Documentation & Polish complete
 - [x] Implementation complete
-- [x] GitHub pipeline security fixes complete
-- [x] Code security vulnerability fixes complete
-- [x] Golangci-lint fixes complete
-- [x] Testing complete
-- [x] Reflection complete
-- [x] Archiving complete
+- [x] Workflow file created and validated
+- [x] Pre-commit validation passed
+- [x] Git commit successful
+- [x] Ready for testing with actual comments
 
-## Security Fixes Completed (2025-01-10)
-
-### CI/CD Pipeline Security Fixes
-- [x] Added `security-events: write` permission to security job
-- [x] Added dependabot exclusion to security job
-- [x] Added timeout configuration to security job
-- [x] Updated `github/codeql-action/upload-sarif` from @v2 to @v3
-- [x] Updated `securego/gosec` from @master to @v2.21.4 (pinned version)
-- [x] Updated `aquasecurity/trivy-action` from @master to @0.28.0 (pinned version)
-- [x] Added `if: always()` condition to SARIF upload for better error handling
-
-### Code Security Vulnerability Fixes
-- [x] Fixed G204 (CWE-78) command injection vulnerabilities in tests/e2e/testutil/
-- [x] Added validateBinaryPath() function to prevent malicious binary execution
-- [x] Added sanitizeArgs() function to remove dangerous characters from command arguments
-- [x] Added validateFilePath() function to prevent path traversal attacks
-- [x] Added secureCommand() function for safe command construction
-- [x] Reduced security issues from 5 to 3 (60% improvement)
-- [x] Remaining 3 issues are false positives with validated inputs in test context
-
-### Code Quality Fixes (2025-01-10)
-- [x] Fixed all 18 golangci-lint issues (err113, exhaustruct, funlen, godot, nlreturn, noinlineerr, wsl_v5)
-- [x] Replaced dynamic errors with static wrapped errors for better error handling
-- [x] Added missing struct fields to prevent incomplete initialization
-- [x] Refactored long functions into smaller, focused functions
-- [x] Fixed comment formatting to end with periods
-- [x] Improved code formatting and whitespace consistency
-- [x] Eliminated inline error handling in favor of explicit error checking
-
-### Test Quality Improvements (2025-01-10)
-- [x] Fixed non-deterministic TestListCommand_PermissionDenied test (lines 108-154)
-- [x] Added ExpectFailure() assertion for permission denied scenarios
-- [x] Added ExpectError() assertion for specific error message "failed to read flows directory"
-- [x] Removed conditional logic that accepted both success and failure outcomes
-- [x] Test now deterministically expects failure with specific error message
-- [x] Verified fix works correctly with all error tests passing
-- [x] Eliminated significant code duplication in test setup across multiple files
-- [x] Created shared test utilities in testutil/setup.go:
-  - [x] StandardFlows map with reusable flow content definitions
-  - [x] CreateFlowsDirectory() for standard directory structure setup
-  - [x] WriteFlowFiles() and WriteStandardFlows() for file creation
-  - [x] SetupTestWithFlows() and SetupTestWithCustomFlows() for complete test setup
-  - [x] TestExecutionWrapper for common execution patterns with timing and coverage
-  - [x] CreateSingleFlow() utility for dynamic flow creation
-- [x] Refactored flow_basic_test.go to use shared utilities (eliminated ~80 lines of duplication)
-- [x] Refactored flow_conditional_test.go to use shared utilities (eliminated ~70 lines of duplication)
-- [x] Refactored flow_error_test.go key tests to use shared utilities (eliminated ~60 lines of duplication)
-- [x] Removed redundant testutil.EnsureBinaryExists() calls (handled by TestExecutionWrapper)
-- [x] Removed redundant testutil.RecordTestExecution() calls (handled by TestExecutionWrapper)
-- [x] Removed redundant directory setup code across all test files
-- [x] Verified all e2e tests continue to pass after refactoring (100% test success rate)
-
-**Security Impact**: Eliminated real command injection and path traversal vulnerabilities while maintaining CI/CD pipeline security compliance.
-
-**Quality Impact**: Achieved 100% golangci-lint compliance with improved code maintainability and error handling.
-
-**Test Impact**: Improved test reliability by eliminating non-deterministic behavior and adding clear pass/fail criteria. Eliminated ~210 lines of code duplication across test files through shared utilities, improving maintainability and consistency.
+## Next Steps
+- Ready for PR creation and testing with real comments
+- Workflow will automatically trigger when comments are added to PRs or Issues


### PR DESCRIPTION
- Add GitHub Actions workflow for PR/Issue comment monitoring
- Configure issue_comment event trigger for both PRs and Issues
- Output comment author, body, PR/Issue number, repository, timestamp
- Follow existing CI patterns with minimal permissions
- Set 5-minute timeout and exclude dependabot comments
- Include additional details like comment ID, URL, issue title, and state

**Related Issue**: #8: Add GitHub Actions workflow for PR/Issue comment monitoring

This feature enables automatic monitoring of all comments on Pull Requests and Issues, providing visibility into community engagement and facilitating automated responses or notifications in the future.